### PR TITLE
Coverage test to use small executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,9 @@ jobs:
           paths:
             - coverage
   coverage:
-    executor: sb_node
+    executor:
+      class: small
+      name: sb_node
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
the coverage test is just uploading coverage reports, so i figured it could also use the small executor